### PR TITLE
Add message sender JID and info source fields to MessageInfo

### DIFF
--- a/message.go
+++ b/message.go
@@ -99,11 +99,14 @@ MessageInfo contains general message information. It is part of every of every m
 type MessageInfo struct {
 	Id              string
 	RemoteJid       string
+	SenderJid       string
 	FromMe          bool
 	Timestamp       uint64
 	PushName        string
 	Status          MessageStatus
 	QuotedMessageID string
+
+	Source *proto.WebMessageInfo
 }
 
 type MessageStatus int
@@ -121,10 +124,12 @@ func getMessageInfo(msg *proto.WebMessageInfo) MessageInfo {
 	return MessageInfo{
 		Id:        msg.GetKey().GetId(),
 		RemoteJid: msg.GetKey().GetRemoteJid(),
+		SenderJid: msg.GetKey().GetParticipant(),
 		FromMe:    msg.GetKey().GetFromMe(),
 		Timestamp: msg.GetMessageTimestamp(),
 		Status:    MessageStatus(msg.GetStatus()),
 		PushName:  msg.GetPushName(),
+		Source:    msg,
 	}
 }
 


### PR DESCRIPTION
There didn't seem to be any way to get the message sender in group chats. This pull request adds a `SenderJid` field to fix that. The field name doesn't follow Go conventions (it should be `SenderJID`), since the `Id` and `RemoteJid` fields don't either.

It seems to be empty when `FromMe` is true. Not sure if there's a way to fill the field manually in that case, does the client know its own JID?

I also added a `Source` field so programs using the library can access the fields that aren't used by the library yet.