### PR TITLE
This fix addresses an out of memory issue due to increased buffer utilization and fixes "panic: repeated read on failed websocket connection" issue

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -153,8 +153,8 @@ func (wac *Conn) isConnected() bool {
 // connect should be guarded with wsConnMutex
 func (wac *Conn) connect() error {
 	dialer := &websocket.Dialer{
-		ReadBufferSize:   25 * 1024 * 1024,
-		WriteBufferSize:  10 * 1024 * 1024,
+		ReadBufferSize:   0,
+		WriteBufferSize:  0,
 		HandshakeTimeout: wac.msgTimeout,
 	}
 


### PR DESCRIPTION
1. Decreased buffer allocation of gorilla websocket to 0 to reuse memory.
2. The websocket connection is reinitialized when the number of errors is equal to 500, as gorilla websocket causes a panic when the number of errors encountered is equal to 1000.
