### PR TITLE
Disconnect() check if session is nil for safety

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -2,11 +2,12 @@
 package whatsapp
 
 import (
-	"github.com/pkg/errors"
 	"math/rand"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/gorilla/websocket"
 )
@@ -184,6 +185,10 @@ func (wac *Conn) Disconnect() (Session, error) {
 
 	err := wac.ws.conn.Close()
 	wac.ws = nil
+
+	if wac.session == nil {
+		return Session{}, err
+	}
 	return *wac.session, err
 }
 

--- a/conn.go
+++ b/conn.go
@@ -7,9 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/gorilla/websocket"
+	"github.com/pkg/errors"
 )
 
 type metric byte


### PR DESCRIPTION
If you attempt to disconnect while the session is not authenticated (with `wac.Logout()`) a panic occurs.

Fixes #123 