### PR TITLE
removing clear listener in processReadData, causing freeze on call queries

### DIFF
--- a/read.go
+++ b/read.go
@@ -56,9 +56,9 @@ func (wac *Conn) processReadData(msgType int, msg []byte) error {
 	}
 
 	if len(data) != 2 || len(data[1]) == 0 {
-		wac.listener.Lock()
-		delete(wac.listener.m, data[0])
-		wac.listener.Unlock()
+		// wac.listener.Lock()
+		// delete(wac.listener.m, data[0])
+		// wac.listener.Unlock()
 		return ErrInvalidWsData
 	}
 


### PR DESCRIPTION
The logic to clear listeners when the data is empty was causing that queries (LoadMessages, Chats, Contacts etc) do not respond never