### PR TITLE
Added AdminTest to try phone connectivity

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -193,6 +193,19 @@ func (wac *Conn) Disconnect() (Session, error) {
 	return *wac.session, err
 }
 
+func (wac *Conn) AdminTest() (bool, error) {
+	if !wac.connected {
+		return false, ErrNotConnected
+	}
+
+	if !wac.loggedIn {
+		return false, ErrInvalidSession
+	}
+
+	result, err := wac.sendAdminTest()			
+	return result, err
+}
+
 func (wac *Conn) keepAlive(minIntervalMs int, maxIntervalMs int) {
 	defer wac.wg.Done()
 

--- a/examples/receiveMessages/main.go
+++ b/examples/receiveMessages/main.go
@@ -73,6 +73,13 @@ func main() {
 		log.Fatalf("error logging in: %v\n", err)
 	}
 
+	//verifies phone connectivity
+	pong, err := wac.AdminTest()
+
+	if !pong || err != nil {
+		log.Fatalf("error pinging in: %v\n", err)
+	}
+
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	<-c


### PR DESCRIPTION
As mentioned in https://github.com/Rhymen/go-whatsapp/issues/85, it's possible to verify phone connectivity via ["admin", "test"] command which returns ["Pong", true] when everything is ok.

This PR adds a new method called AdminTest() to be used any moment in any implementation.

At the WppWeb, this verification is only called when phone is unreachable in a way that I couldn't understand yet. So I suggest only call that in weird behaviours on your connectivity for a while.

