### PR TITLE
voice recording: passing info of ptt (push to talk) to wpp

### DIFF
--- a/message.go
+++ b/message.go
@@ -4,13 +4,14 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/Rhymen/go-whatsapp/binary"
-	"github.com/Rhymen/go-whatsapp/binary/proto"
 	"io"
 	"math/rand"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Rhymen/go-whatsapp/binary"
+	"github.com/Rhymen/go-whatsapp/binary/proto"
 )
 
 type MediaType string
@@ -337,6 +338,7 @@ type AudioMessage struct {
 	Length        uint32
 	Type          string
 	Content       io.Reader
+	Ptt           bool
 	url           string
 	mediaKey      []byte
 	fileEncSha256 []byte
@@ -369,6 +371,7 @@ func getAudioProto(msg AudioMessage) *proto.WebMessageInfo {
 			FileSha256:    msg.fileSha256,
 			FileLength:    &msg.fileLength,
 			Mimetype:      &msg.Type,
+			Ptt:           &msg.Ptt,
 		},
 	}
 	return p


### PR DESCRIPTION
I have a few learnings about sending Voice Recordings to Whatsapp, but it's not a concern of the library to deal with that.

I will explain it below as sort of a documentation:

- WhatsApp uses bit `Ptt` to indicate clients that it's a Voice Recording
- It uses a `audio/ogg` mimeType, but with specific codec called `opus`: `audio/ogg; codecs=opus`
- Few browsers support recording `opus` natively. So libs like `opus-media-recorder` overrides default `MediaRecorder API` and turns it possible
- If you send the recording audio as `audio/mpeg` (.mp3), it'll show up as an attachment and it won't play in iPhone devices.