### PR TITLE
Fix content convert to node without check issue

### DIFF
--- a/binary/node.go
+++ b/binary/node.go
@@ -66,9 +66,12 @@ func Unmarshal(data []byte) (*Node, error) {
 	}
 
 	if n != nil && n.Attributes != nil && n.Content != nil {
-		n.Content, err = unmarshalMessageArray(n.Content.([]Node))
-		if err != nil {
-			return nil, err
+		nContent, ok := n.Content.([]Node)
+		if ok {
+			n.Content, err = unmarshalMessageArray(nContent)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi

When I use below code to query url:

I add this code into group.go for test.
```golang
func (wac *Conn) QueryUrlByInviteCode(link string) (*binary.Node, error) {
	ts := time.Now().Unix()
	tag := fmt.Sprintf("%d.--%d", ts, wac.msgCount)
	n := binary.Node{
		Description: "query",
		Attributes: map[string]string{
			"type":  "url",
			"epoch": strconv.Itoa(wac.msgCount),
			"url":   link,
		},
	}

	metric := group
	ch, err := wac.writeBinary(n, metric, ignore, tag)
	if err != nil {
		return nil, err
	}
	msg, err := wac.decryptBinaryMessage([]byte(<-ch))
	if err != nil {
		return nil, err
	}

	fmt.Printf("canonical-url:%s\n", msg.Attributes["canonical-url"])
	fmt.Printf("description:%s\n", msg.Attributes["description"])
	fmt.Printf("matched-text:%s\n", msg.Attributes["matched-text"])
	fmt.Printf("title:%s\n", msg.Attributes["title"])
	return msg, nil
}
```
>  (this process usually trigger by input some message with group invite code into web whatsapp  and wait for seconds, then it will show a card with group infomation.)

then run this code:
```golang
        n, err := wac.QueryUrlByInviteCode("https://chat.whatsapp.com/IG97z9ogiNN5YwtyZBL7oZ")
	if err != nil {
		panic(err)
	}
```

error message:
```
panic: interface conversion: interface {} is []uint8, not []binary.Node
goroutine 1 [running]:
github.com/Rhymen/go-whatsapp/binary.Unmarshal(0xc003dd2030, 0xb17, 0xbd0, 0x0, 0x0, 0x0)
        /mnt/d/code/go/src/greyyang/go-whatsapp/binary/node.go:69 +0x1d6
github.com/Rhymen/go-whatsapp.(*Conn).decryptBinaryMessage(0xc0000f8000, 0xc003dd2000, 0xb50, 0xc00, 0xb50, 0xc00, 0x800a)
        /mnt/d/code/go/src/greyyang/go-whatsapp/read.go:128 +0x40a
github.com/Rhymen/go-whatsapp.(*Conn).QueryUrlByInviteCode(0xc0000f8000, 0x87346e, 0x30, 0x1e, 0xc0003d9e50, 0x1)
        /mnt/d/code/go/src/greyyang/go-whatsapp/group.go:111 +0x3ab
main.main()
        /mnt/d/code/go/src/greyyang/go-whatsapp/examples/loginWithProxy/main.go:37 +0x30f
exit status 2
```
I found the error code have type convert without check.
```golang
func Unmarshal(data []byte) (*Node, error) {
	r := NewDecoder(data)
	n, err := r.ReadNode()
	if err != nil {
		return nil, err
	}

	if n != nil && n.Attributes != nil && n.Content != nil {
		n.Content, err = unmarshalMessageArray(n.Content.([]Node))
		if err != nil {
			return nil, err
		}
	}

	return n, nil
}
```

When query url with whatsapp group invite link the `n.Content` is the group avatar ( raw base64 jpeg byte array, which may be used by `ExtendedTextMessage.JpegThumbnail` or display directly on the web), so I think it should be returned as it is.

I have a quick fix with this issue. Please check. Thanks.

