### PR TITLE
Fix error in "echo" example: "assignment mismatch"

### DIFF
--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -34,7 +34,7 @@ func (wh *waHandler) HandleTextMessage(message whatsapp.TextMessage) {
 		Text: message.Text,
 	}
 
-	if err := wh.wac.Send(msg); err != nil {
+	if _, err := wh.wac.Send(msg); err != nil {
 		fmt.Fprintf(os.Stderr, "error sending message: %v\n", err)
 	}
 


### PR DESCRIPTION
Hey, 
while testing around I found an error in "echo" example which is not compiling anymore:
`./main.go:37:9: assignment mismatch: 1 variable but wh.wac.Send returns 2 values`
With the fix the whole example is working pretty fine again for me :+1: 