### PR TITLE
bug fix semacquire

### DIFF
--- a/read.go
+++ b/read.go
@@ -15,7 +15,10 @@ import (
 )
 
 func (wac *Conn) readPump() {
-	defer wac.wg.Done()
+	defer func() {
+		wac.wg.Done()
+		_, _ = wac.Disconnect()
+	}()
 
 	var readErr error
 	var msgType int
@@ -31,7 +34,6 @@ func (wac *Conn) readPump() {
 		case <-readerFound:
 			if readErr != nil {
 				wac.handle(&ErrConnectionFailed{Err: readErr})
-				_, _ = wac.Disconnect()
 				return
 			}
 			msg, err := ioutil.ReadAll(reader)


### PR DESCRIPTION
Disconnect call to select occurs before wac.wg.Done () is created semacquire on Disconnect and causes a memory leak