### PR TITLE
Fix/readpumppanic #331

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -202,18 +202,9 @@ func (wac *Conn) Disconnect() (Session, error) {
 	wac.loggedIn = false
 
 	close(wac.ws.close) //signal close
-	done := make(chan struct{})
-	go func() {
-		wac.wg.Wait()
-		close(done)
-	}()
-	var err error
-	select {
-	case <-done:
-	case <-time.After(wac.msgTimeout):
-		err = wac.ws.conn.Close()
-	}
-	<-done
+	wac.wg.Wait()       //wait for close
+
+	err := wac.ws.conn.Close()
 	wac.ws = nil
 
 	if wac.session == nil {

--- a/read.go
+++ b/read.go
@@ -5,13 +5,14 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+
 	"github.com/Rhymen/go-whatsapp/binary"
 	"github.com/Rhymen/go-whatsapp/crypto/cbc"
 	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"
-	"io"
-	"io/ioutil"
-	"strings"
 )
 
 func (wac *Conn) readPump() {
@@ -27,7 +28,9 @@ func (wac *Conn) readPump() {
 	for {
 		readerFound := make(chan struct{})
 		go func() {
-			msgType, reader, readErr = wac.ws.conn.NextReader()
+			if wac.ws != nil {
+				msgType, reader, readErr = wac.ws.conn.NextReader()
+			}
 			close(readerFound)
 		}()
 		select {


### PR DESCRIPTION
The fix just check if ws is nil before running nextreader.

Fixes a rare panic (#331) that happens when disconnect runs right after the creation of nextreader goroutine. So, read pump is closed, the socket becomes nil, and then goroutine will try to get conn.NextReader() from nil raising panic.
