### PR TITLE
Fix/buffersize Causing high memory usage

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -156,8 +156,8 @@ func (wac *Conn) connect() (err error) {
 	}()
 
 	dialer := &websocket.Dialer{
-		ReadBufferSize:   25 * 1024 * 1024,
-		WriteBufferSize:  10 * 1024 * 1024,
+		ReadBufferSize:   0,
+		WriteBufferSize:  0,
 		HandshakeTimeout: wac.msgTimeout,
 		Proxy:            wac.Proxy,
 	}


### PR DESCRIPTION
Websocket buffer size was causing high memory usage during ws conn, issues tracking:

Suggest in #282 , discussion in #328  and benchmark/testing in #350 

ps: re-opening pr