### PR TITLE
Update media struct

### DIFF
--- a/media.go
+++ b/media.go
@@ -101,10 +101,7 @@ type MediaConn struct {
                 TTL int `json:"ttl"`                                            
                 Hosts []struct {                                                
                         Hostname string `json:"hostname"`                       
-                        IPs []struct {                                          
-                                IP4 string `json:"ip4"`                         
-                                IP6 string `json:"ip6"`                         
-                        }                                                       
+                        IPs []interface{}                                                       
                 } `json:"hosts"`                                                
         } `json:"media_conn"`                                                   
 }

--- a/media.go
+++ b/media.go
@@ -101,7 +101,7 @@ type MediaConn struct {
                 TTL int `json:"ttl"`                                            
                 Hosts []struct {                                                
                         Hostname string `json:"hostname"`                       
-                        IPs []interface{}                                                       
+                        IPs []interface{}  `json:"ips"`                                              
                 } `json:"hosts"`                                                
         } `json:"media_conn"`                                                   
 }

--- a/media.go
+++ b/media.go
@@ -93,17 +93,23 @@ func downloadMedia(url string) (file []byte, mac []byte, err error) {
 	return data[:n-10], data[n-10 : n], nil
 }
 
-type MediaConn struct {
-	Status    int `json:"status"`
-	MediaConn struct {
-		Auth  string `json:"auth"`
-		TTL   int    `json:"ttl"`
-		Hosts []struct {
-			Hostname string   `json:"hostname"`
-			IPs      []string `json:"ips"`
-		} `json:"hosts"`
-	} `json:"media_conn"`
+                                                                                
+type MediaConn struct {                                                         
+        Status int `json:"status"`                                              
+        MediaConn struct {                                                      
+                Auth string `json:"auth"`                                       
+                TTL int `json:"ttl"`                                            
+                Hosts []struct {                                                
+                        Hostname string `json:"hostname"`                       
+                        IPs []struct {                                          
+                                IP4 string `json:"ip4"`                         
+                                IP6 string `json:"ip6"`                         
+                        }                                                       
+                } `json:"hosts"`                                                
+        } `json:"media_conn"`                                                   
 }
+
+
 
 func (wac *Conn) queryMediaConn() (hostname, auth string, ttl int, err error) {
 	queryReq := []interface{}{"query", "mediaConn"}


### PR DESCRIPTION
Credit to @ramacatur https://github.com/Rhymen/go-whatsapp/issues/363#issuecomment-631268278

Today, WhatsApp decide to update the json response which sometimes includes ip6 url formats, which break the hostname. 
It affects media uploads functionality. 

Thanks to @ramacatur, who catch this. 

Regard 

