### PR TITLE
Allowing to resuse media url

### DIFF
--- a/media.go
+++ b/media.go
@@ -18,6 +18,15 @@ import (
 	"github.com/Rhymen/go-whatsapp/crypto/hkdf"
 )
 
+//
+type Media struct {
+	downloadURL   string
+	mediaKey      []byte
+	fileEncSha256 []byte
+	fileSha256    []byte
+	fileLength    uint64
+}
+
 func Download(url string, mediaKey []byte, appInfo MediaType, fileLength int) ([]byte, error) {
 	if url == "" {
 		return nil, fmt.Errorf("no url present")
@@ -130,10 +139,10 @@ func (wac *Conn) queryMediaConn() (hostname, auth string, ttl int, err error) {
 }
 
 var mediaTypeMap = map[MediaType]string{
-	MediaImage: "/mms/image",
-	MediaVideo: "/mms/video",
+	MediaImage:    "/mms/image",
+	MediaVideo:    "/mms/video",
 	MediaDocument: "/mms/document",
-	MediaAudio: "/mms/audio",
+	MediaAudio:    "/mms/audio",
 }
 
 func (wac *Conn) Upload(reader io.Reader, appInfo MediaType) (downloadURL string, mediaKey []byte, fileEncSha256 []byte, fileSha256 []byte, fileLength uint64, err error) {

--- a/media.go
+++ b/media.go
@@ -20,11 +20,11 @@ import (
 
 //
 type Media struct {
-	downloadURL   string
-	mediaKey      []byte
-	fileEncSha256 []byte
-	fileSha256    []byte
-	fileLength    uint64
+	DownloadURL   string
+	MediaKey      []byte
+	FileEncSha256 []byte
+	FileSha256    []byte
+	FileLength    uint64
 }
 
 func Download(url string, mediaKey []byte, appInfo MediaType, fileLength int) ([]byte, error) {
@@ -150,7 +150,7 @@ func (wac *Conn) uploadMedia(m *Media, reader io.Reader, appInfo MediaType) (dow
 	if m == nil {
 		return wac.Upload(reader, appInfo)
 	}
-	return m.downloadURL, m.mediaKey, m.fileEncSha256, m.fileSha256, m.fileLength, nil
+	return m.DownloadURL, m.MediaKey, m.FileEncSha256, m.FileSha256, m.FileLength, nil
 }
 
 func (wac *Conn) Upload(reader io.Reader, appInfo MediaType) (downloadURL string, mediaKey []byte, fileEncSha256 []byte, fileSha256 []byte, fileLength uint64, err error) {

--- a/media.go
+++ b/media.go
@@ -145,6 +145,14 @@ var mediaTypeMap = map[MediaType]string{
 	MediaAudio:    "/mms/audio",
 }
 
+// Upload only when media is nill
+func (wac *Conn) uploadMedia(m *Media, reader io.Reader, appInfo MediaType) (downloadURL string, mediaKey []byte, fileEncSha256 []byte, fileSha256 []byte, fileLength uint64, err error) {
+	if m == nil {
+		return wac.Upload(reader, appInfo)
+	}
+	return m.downloadURL, m.mediaKey, m.fileEncSha256, m.fileSha256, m.fileLength, nil
+}
+
 func (wac *Conn) Upload(reader io.Reader, appInfo MediaType) (downloadURL string, mediaKey []byte, fileEncSha256 []byte, fileSha256 []byte, fileLength uint64, err error) {
 	data, err := ioutil.ReadAll(reader)
 	if err != nil {

--- a/message.go
+++ b/message.go
@@ -23,8 +23,14 @@ const (
 	MediaDocument MediaType = "WhatsApp Document Keys"
 )
 
-func (wac *Conn) Send(msg interface{}) (string, error) {
+// Since there is no optional variable in go, using this as a workaround
+func (wac *Conn) Send(msg interface{}, medias ...Media) (string, error) {
 	var msgProto *proto.WebMessageInfo
+	var media *Media
+
+	if len(medias) > 0 {
+		media = &medias[0]
+	}
 
 	switch m := msg.(type) {
 	case *proto.WebMessageInfo:
@@ -33,28 +39,28 @@ func (wac *Conn) Send(msg interface{}) (string, error) {
 		msgProto = getTextProto(m)
 	case ImageMessage:
 		var err error
-		m.url, m.mediaKey, m.fileEncSha256, m.fileSha256, m.fileLength, err = wac.Upload(m.Content, MediaImage)
+		m.url, m.mediaKey, m.fileEncSha256, m.fileSha256, m.fileLength, err = wac.uploadMedia(media, m.Content, MediaImage)
 		if err != nil {
 			return "ERROR", fmt.Errorf("image upload failed: %v", err)
 		}
 		msgProto = getImageProto(m)
 	case VideoMessage:
 		var err error
-		m.url, m.mediaKey, m.fileEncSha256, m.fileSha256, m.fileLength, err = wac.Upload(m.Content, MediaVideo)
+		m.url, m.mediaKey, m.fileEncSha256, m.fileSha256, m.fileLength, err = wac.uploadMedia(media, m.Content, MediaVideo)
 		if err != nil {
 			return "ERROR", fmt.Errorf("video upload failed: %v", err)
 		}
 		msgProto = getVideoProto(m)
 	case DocumentMessage:
 		var err error
-		m.url, m.mediaKey, m.fileEncSha256, m.fileSha256, m.fileLength, err = wac.Upload(m.Content, MediaDocument)
+		m.url, m.mediaKey, m.fileEncSha256, m.fileSha256, m.fileLength, err = wac.uploadMedia(media, m.Content, MediaDocument)
 		if err != nil {
 			return "ERROR", fmt.Errorf("document upload failed: %v", err)
 		}
 		msgProto = getDocumentProto(m)
 	case AudioMessage:
 		var err error
-		m.url, m.mediaKey, m.fileEncSha256, m.fileSha256, m.fileLength, err = wac.Upload(m.Content, MediaAudio)
+		m.url, m.mediaKey, m.fileEncSha256, m.fileSha256, m.fileLength, err = wac.uploadMedia(media, m.Content, MediaAudio)
 		if err != nil {
 			return "ERROR", fmt.Errorf("audio upload failed: %v", err)
 		}


### PR DESCRIPTION
This decouples media upload from message send function, this allows to separate upload call, and hence the caller can decide to reuse media URL for broadcast