### PR TITLE
Implement receive name for new contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ func (myHandler) HandleContactMessage(message whatsapp.ContactMessage) {
 	fmt.Println(message)
 }
 
+func (myHandler) HandleBatteryMessage(msg whatsapp.BatteryMessage) {
+	fmt.Println(message)
+}
+
 wac.AddHandler(myHandler{})
 ```
 The message handlers are all optional, you don't need to implement anything but the error handler to implement the interface. The ImageMessage, VideoMessage, AudioMessage and DocumentMessage provide a Download function to get the media data.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ func (myHandler) HandleBatteryMessage(msg whatsapp.BatteryMessage) {
 }
 
 func (myHandler) HandleNewContact(contact whatsapp.Contact) {
-	fmt.Println(message)
+	fmt.Println(contact)
 }
 
 wac.AddHandler(myHandler{})

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ func (myHandler) HandleBatteryMessage(msg whatsapp.BatteryMessage) {
 	fmt.Println(message)
 }
 
+func (myHandler) HandleNewContact(contact whatsapp.Contact) {
+	fmt.Println(message)
+}
+
 wac.AddHandler(myHandler{})
 ```
 The message handlers are all optional, you don't need to implement anything but the error handler to implement the interface. The ImageMessage, VideoMessage, AudioMessage and DocumentMessage provide a Download function to get the media data.

--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -19,10 +19,6 @@ func (wh *waHandler) HandleError(err error) {
 	fmt.Fprintf(os.Stderr, "error caught in handler: %v\n", err)
 }
 
-func (wh *waHandler) HandleNewContact(contact whatsapp.Contact) {
-	fmt.Printf("Recebendo um novo contato: %v", contact)
-}
-
 // HandleTextMessage receives whatsapp text messages and checks if the message was send by the current
 // user, if it does not contain the keyword '@echo' or if it is from before the program start and then returns.
 // Otherwise the message is echoed back to the original author.

--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -19,6 +19,10 @@ func (wh *waHandler) HandleError(err error) {
 	fmt.Fprintf(os.Stderr, "error caught in handler: %v\n", err)
 }
 
+func (wh *waHandler) HandleNewContact(contact whatsapp.Contact) {
+	fmt.Printf("Recebendo um novo contato: %v", contact)
+}
+
 // HandleTextMessage receives whatsapp text messages and checks if the message was send by the current
 // user, if it does not contain the keyword '@echo' or if it is from before the program start and then returns.
 // Otherwise the message is echoed back to the original author.

--- a/handler.go
+++ b/handler.go
@@ -141,6 +141,14 @@ type BatteryMessageHandler interface {
 	HandleBatteryMessage(battery BatteryMessage)
 }
 
+/**
+The NewContactHandler interface needs to be implemented to receive the contact's name for the first time.
+*/
+type NewContactHandler interface {
+	Handler
+	HandleNewContact(contact Contact)
+}
+
 /*
 AddHandler adds an handler to the list of handler that receive dispatched messages.
 The provided handler must at least implement the Handler interface. Additionally implemented
@@ -304,6 +312,17 @@ func (wac *Conn) handleWithCustomHandlers(message interface{}, handlers []Handle
 				}
 			}
 		}
+	
+	case Contact:
+		for _, h := range handlers {
+			if x, ok := h.(NewContactHandler); ok {
+				if wac.shouldCallSynchronously(h) {
+					x.HandleNewContact(m)
+				} else {
+					go x.HandleNewContact(m)
+				}
+			}
+		}
 
 	case *proto.WebMessageInfo:
 		for _, h := range handlers {
@@ -396,6 +415,10 @@ func (wac *Conn) dispatch(msg interface{}) {
 					if v, ok := con[a].(*proto.WebMessageInfo); ok {
 						wac.handle(v)
 						wac.handle(ParseProtoMessage(v))
+					}
+
+					if v, ok := con[a].(binary.Node); ok {
+						wac.handle(ParseNodeMessage(v))
 					}
 				}
 			} else if con, ok := message.Content.([]binary.Node); ok {

--- a/message.go
+++ b/message.go
@@ -771,7 +771,7 @@ func getBatteryMessage(msg map[string]string) BatteryMessage {
 func getNewContact(msg map[string]string) Contact {
 	contact := Contact{
 		Jid: msg["jid"],
-		Name: msg["notify"],
+		Notify: msg["notify"],
 	}
 
 	return contact

--- a/message.go
+++ b/message.go
@@ -744,3 +744,38 @@ func ParseProtoMessage(msg *proto.WebMessageInfo) interface{} {
 
 	return nil
 }
+
+
+/*
+BatteryMessage represents a battery level and charging state.
+*/
+type BatteryMessage struct {
+	Plugged bool
+	Powersave bool
+	Percentage int
+}
+
+func getBatteryMessage(msg map[string]string) BatteryMessage {
+	plugged, _ := strconv.ParseBool(msg["live"])
+	powersave, _ := strconv.ParseBool(msg["powersave"])
+	percentage, _ := strconv.Atoi(msg["value"])
+	batteryMessage := BatteryMessage{
+		Plugged: plugged,
+		Powersave: powersave,
+		Percentage: percentage,
+	}
+
+	return batteryMessage
+}
+
+
+func ParseNodeMessage(msg binary.Node) interface{} {
+	switch msg.Description {
+	case "battery":
+		return getBatteryMessage(msg.Attributes)
+	default:
+		//cannot match message
+	}
+
+	return nil
+}

--- a/message.go
+++ b/message.go
@@ -768,11 +768,21 @@ func getBatteryMessage(msg map[string]string) BatteryMessage {
 	return batteryMessage
 }
 
+func getNewContact(msg map[string]string) Contact {
+	contact := Contact{
+		Jid: msg["jid"],
+		Name: msg["notify"],
+	}
+
+	return contact
+}
 
 func ParseNodeMessage(msg binary.Node) interface{} {
 	switch msg.Description {
 	case "battery":
 		return getBatteryMessage(msg.Attributes)
+	case "user":
+		return getNewContact(msg.Attributes)
 	default:
 		//cannot match message
 	}


### PR DESCRIPTION
This method implements receiving the name of new contacts that are not in the device's contact list.

With that there is no need to restart the session to receive updated contacts.

Related issues:
- #315
- #294