### PR TITLE
Whatsapp: Update waVersion to version 2.2033.7 and Deprecated clientVersion 

### DIFF
--- a/session.go
+++ b/session.go
@@ -18,7 +18,7 @@ import (
 )
 
 //represents the WhatsAppWeb client version
-var waVersion = var waVersion = []int{2, 2031, 4} //[]int{0, 4, 2080}
+var waVersion = var waVersion = []int{2, 2033, 7} //[]int{0, 4, 2080}
 
 /*
 Session contains session individual information. To be able to resume the connection without scanning the qr code

--- a/session.go
+++ b/session.go
@@ -18,7 +18,7 @@ import (
 )
 
 //represents the WhatsAppWeb client version
-var waVersion = var waVersion = []int{2, 2033, 7} //[]int{0, 4, 2080}
+var waVersion = []int{2, 2033, 7}
 
 /*
 Session contains session individual information. To be able to resume the connection without scanning the qr code
@@ -141,11 +141,11 @@ func CheckCurrentServerVersion() ([]int, error) {
 SetClientName sets the long and short client names that are sent to WhatsApp when logging in and displayed in the
 WhatsApp Web device list. As the values are only sent when logging in, changing them after logging in is not possible.
 */
-func (wac *Conn) SetClientName(long, short, version string) error {
+func (wac *Conn) SetClientName(long, short string) error {
 	if wac.session != nil && (wac.session.EncKey != nil || wac.session.MacKey != nil) {
 		return fmt.Errorf("cannot change client name after logging in")
 	}
-	wac.longClientName, wac.shortClientName, wac.clientVersion = long, short, version
+	wac.longClientName, wac.shortClientName = long, short
 	return nil
 }
 

--- a/session.go
+++ b/session.go
@@ -18,7 +18,7 @@ import (
 )
 
 //represents the WhatsAppWeb client version
-var waVersion = []int{0, 4, 2080}
+var waVersion = var waVersion = []int{2, 2031, 4} //[]int{0, 4, 2080}
 
 /*
 Session contains session individual information. To be able to resume the connection without scanning the qr code


### PR DESCRIPTION
https://user-images.githubusercontent.com/4635115/89966167-30f74b80-dc57-11ea-9e31-517e7dace0da.png
Whatsapp chrome update waVersion  and i can not see the anything about the clientVirsion in the chorme!