### PR TITLE
Updating WhatsAppWeb client version

### DIFF
--- a/session.go
+++ b/session.go
@@ -18,7 +18,7 @@ import (
 )
 
 //represents the WhatsAppWeb client version
-var waVersion = []int{2, 2033, 7}
+var waVersion = []int{2, 2035, 14}
 
 /*
 Session contains session individual information. To be able to resume the connection without scanning the qr code
@@ -141,11 +141,11 @@ func CheckCurrentServerVersion() ([]int, error) {
 SetClientName sets the long and short client names that are sent to WhatsApp when logging in and displayed in the
 WhatsApp Web device list. As the values are only sent when logging in, changing them after logging in is not possible.
 */
-func (wac *Conn) SetClientName(long, short string) error {
+func (wac *Conn) SetClientName(long, short string, version string) error {
 	if wac.session != nil && (wac.session.EncKey != nil || wac.session.MacKey != nil) {
 		return fmt.Errorf("cannot change client name after logging in")
 	}
-	wac.longClientName, wac.shortClientName = long, short
+	wac.longClientName, wac.shortClientName, wac.clientVersion = long, short, version
 	return nil
 }
 


### PR DESCRIPTION
It seems there is New minor update to 2035.
and I note that WhatsApp changes the client version to use the OS version. 
Well, I take back the update as the @tulir Advice. Thanks, tulir  : https://github.com/Rhymen/go-whatsapp/pull/431#issuecomment-681146713
But I kept function names as it is so there is no backward compatibility problem