### PR TITLE
Break MediaConn's IPs to struct to handle IPv4 and IPv6.

### DIFF
--- a/media.go
+++ b/media.go
@@ -93,20 +93,20 @@ func downloadMedia(url string) (file []byte, mac []byte, err error) {
 	return data[:n-10], data[n-10 : n], nil
 }
 
-                                                                                
-type MediaConn struct {                                                         
-        Status int `json:"status"`                                              
-        MediaConn struct {                                                      
-                Auth string `json:"auth"`                                       
-                TTL int `json:"ttl"`                                            
-                Hosts []struct {                                                
-                        Hostname string `json:"hostname"`                       
-                        IPs []interface{}  `json:"ips"`                                              
-                } `json:"hosts"`                                                
-        } `json:"media_conn"`                                                   
+type MediaConn struct {
+	Status    int `json:"status"`
+	MediaConn struct {
+		Auth  string `json:"auth"`
+		TTL   int    `json:"ttl"`
+		Hosts []struct {
+			Hostname string `json:"hostname"`
+			IPs      []struct {
+				IP4 string `json:"ip4"`
+				IP6 string `json:"ip6"`
+			} `json:"ips"`
+		} `json:"hosts"`
+	} `json:"media_conn"`
 }
-
-
 
 func (wac *Conn) queryMediaConn() (hostname, auth string, ttl int, err error) {
 	queryReq := []interface{}{"query", "mediaConn"}
@@ -131,7 +131,7 @@ func (wac *Conn) queryMediaConn() (hostname, auth string, ttl int, err error) {
 
 	var host string
 	for _, h := range resp.MediaConn.Hosts {
-		if h.Hostname!="" {
+		if h.Hostname != "" {
 			host = h.Hostname
 			break
 		}
@@ -143,10 +143,10 @@ func (wac *Conn) queryMediaConn() (hostname, auth string, ttl int, err error) {
 }
 
 var mediaTypeMap = map[MediaType]string{
-	MediaImage: "/mms/image",
-	MediaVideo: "/mms/video",
+	MediaImage:    "/mms/image",
+	MediaVideo:    "/mms/video",
 	MediaDocument: "/mms/document",
-	MediaAudio: "/mms/audio",
+	MediaAudio:    "/mms/audio",
 }
 
 func (wac *Conn) Upload(reader io.Reader, appInfo MediaType) (downloadURL string, mediaKey []byte, fileEncSha256 []byte, fileSha256 []byte, fileLength uint64, err error) {


### PR DESCRIPTION
I got some error like `error decoding query media conn response: json: cannot unmarshal object into Go struct field .media_conn.hosts.ips of type string` after trying to send image from the bot.

Response from MediaConn query is now having separated IP for IPv4 and IPv6.

```{
	"status": 200,
	"media_conn": {
		"auth": "redacted",
		"ttl": 21600,
		"hosts": [{
			"hostname": "media-cgk1-1.cdn.whatsapp.net",
			"fallback_hostname": "media-sin6-2.cdn.whatsapp.net",
			"type": "primary",
			"class": "pop",
			"fallback_class": "pop",
			"ips": [{
				"ip4": "157.240.208.60",
				"ip6": "2a03:2880:f24d:c8:face:b00c:0:167"
			}],
			"fallback_ips": [{
				"ip4": "157.240.13.54",
				"ip6": "2a03:2880:f20c:2c6:face:b00c:0:167"
			}],
			"rules": [{
				"download": ["video", "image", "gif", "ptt", "audio", "document", "sticker", "ppic", "md-app-state", "md-msg-hist", "kyc-id", "thumbnail-image", "thumbnail-video", "thumbnail-gif", "thumbnail-document", "thumbnail-link"]
			}, {
				"download_buckets": ["0"]
			}]
		}, {
			"hostname": "media.fcgk10-1.fna.whatsapp.net",
			"fallback_hostname": "media-cgk1-1.cdn.whatsapp.net",
			"type": "primary",
			"class": "fna",
			"fallback_class": "pop",
			"ips": [{
				"ip4": "66.96.225.34"
			}],
			"fallback_ips": [{
				"ip4": "157.240.208.60",
				"ip6": "2a03:2880:f24d:c8:face:b00c:0:167"
			}],
			"rules": [{
				"upload": []
			}, {
				"download": ["video"]
			}, {
				"download_buckets": ["1"]
			}]
		}, {
			"hostname": "mmg.whatsapp.net",
			"type": "fallback",
			"class": "pop",
			"ips": [],
			"rules": []
		}]
	}
}
```