### PR TITLE
Return message ID in case of timeout

### DIFF
--- a/message.go
+++ b/message.go
@@ -87,7 +87,7 @@ func (wac *Conn) Send(msg interface{}) (string, error) {
 			return getMessageInfo(msgProto).Id, nil
 		}
 	case <-time.After(wac.msgTimeout):
-		return "ERROR", fmt.Errorf("sending message timed out")
+		return getMessageInfo(msgProto).Id, fmt.Errorf("sending message timed out")
 	}
 
 	return "ERROR", nil


### PR DESCRIPTION
Hello there.

This small change returns the ID of the sent message in case of timeouts. I found that even if a timeout happens messages are still sent (maybe not always, but in my experience most of the time they are sent).

Returning the ID allows the code to look for ack events in the future. For example, if there was a timeout and we receive an ack for the same ID, it means it was actually sent.

I don't know there would be any issues with this change, but I've been using it for a couple of weeks and it seems to work fine.

Thanks!