### PR TITLE
feat: add GetGroupMetadata

### DIFF
--- a/contact.go
+++ b/contact.go
@@ -27,6 +27,11 @@ func (wac *Conn) GetProfilePicThumb(jid string) (<-chan string, error) {
 	return wac.writeJson(data)
 }
 
+func (wac *Conn) GetGroupMetadata(jid string) (<-chan string, error) {
+	data := []interface{}{"query", "GroupMetadata", jid}
+	return wac.writeJson(data)
+}
+
 func (wac *Conn) GetStatus(jid string) (<-chan string, error) {
 	data := []interface{}{"query", "Status", jid}
 	return wac.writeJson(data)


### PR DESCRIPTION
Hi, i would like to add group metadata ability on Rhymen go-whatsapp. 

This feature will be useful for retrieving group information from JID or searching group (jid) by name. (by utilize Search and validate the group name with this function)

I already try it, and has this result.

`
{"id":"{{phoneNumber}}-16200151212@g.us","owner":"{{phoneNumber}}@c.us","subject":"{{groupName}}","creation":1620015508,"participants":[{"id":"{{phoneNumber1}}@c.us","isAdmin":false,"isSuperAdmin":false},{"id":"{{phoneNumber2}}@c.us","isAdmin":false,"isSuperAdmin":false},{"id":"{{phoneNumber3}}@c.us","isAdmin":false,"isSuperAdmin":false},{"id":"{{phoneNumber4}}@c.us","isAdmin":true,"isSuperAdmin":false},{"id":"{{phoneNumber}}@c.us","isAdmin":true,"isSuperAdmin":true}],"subjectTime":1620015508,"subjectOwner":"{{phoneNumber}}@c.us"} <nil>
`