### PR TITLE
Set loggedIn to false on logout

### DIFF
--- a/session.go
+++ b/session.go
@@ -526,5 +526,7 @@ func (wac *Conn) Logout() error {
 		return fmt.Errorf("error writing logout: %v\n", err)
 	}
 
+	wac.loggedIn = false
+
 	return nil
 }


### PR DESCRIPTION
When logging out and trying to login again, an `alread logged in` error is returned because the `loggedIn` field is still true