### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ func (myHandler) HandleContactMessage(message whatsapp.ContactMessage) {
 	fmt.Println(message)
 }
 
-func (myHandler) HandleBatteryMessage(msg whatsapp.BatteryMessage) {
+func (myHandler) HandleBatteryMessage(message whatsapp.BatteryMessage) {
 	fmt.Println(message)
 }
 


### PR DESCRIPTION
I got 

```
./handlers.go:44:14: undefined: message
```

cause it was called `msg` before.