### PR TITLE
Auto update (bump) minor version

### DIFF
--- a/binary/node_test.go
+++ b/binary/node_test.go
@@ -2,9 +2,10 @@ package binary
 
 import (
 	"fmt"
-	"github.com/Rhymen/go-whatsapp/binary/proto"
 	"reflect"
 	"testing"
+
+	"github.com/Rhymen/go-whatsapp/binary/proto"
 )
 
 func TestMarshal(t *testing.T) {
@@ -19,7 +20,7 @@ func TestMarshal(t *testing.T) {
 		}
 		*msg.Message.Conversation = "Testnachricht."
 
-		msg.Status = new(proto.WebMessageInfo_WEB_MESSAGE_INFO_STATUS)
+		msg.Status = new(proto.WebMessageInfo_WebMessageInfoStatus)
 		*msg.Status = proto.WebMessageInfo_ERROR
 
 		msg.Key = &proto.MessageKey{

--- a/conn.go
+++ b/conn.go
@@ -2,6 +2,7 @@
 package whatsapp
 
 import (
+	"log"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -94,6 +95,8 @@ type Conn struct {
 	shortClientName string
 	clientVersion   string
 
+	autoUpdateTries int // counter for auto update retries
+
 	loginSessionLock sync.RWMutex
 	Proxy            func(*http.Request) (*url.URL, error)
 
@@ -125,29 +128,30 @@ func NewConn(timeout time.Duration) (*Conn, error) {
 func NewConnWithProxy(timeout time.Duration, proxy func(*http.Request) (*url.URL, error)) (*Conn, error) {
 	return NewConnWithOptions(&Options{
 		Timeout: timeout,
-		Proxy: proxy,
+		Proxy:   proxy,
 	})
 }
 
 // NewConnWithOptions Create a new connect with a given options.
 type Options struct {
-	Proxy            func(*http.Request) (*url.URL, error)
-	Timeout          time.Duration
-	Handler          []Handler
-	ShortClientName  string
-	LongClientName   string
-	ClientVersion    string
-	Store            *Store
+	Proxy           func(*http.Request) (*url.URL, error)
+	Timeout         time.Duration
+	Handler         []Handler
+	ShortClientName string
+	LongClientName  string
+	ClientVersion   string
+	Store           *Store
 }
+
 func NewConnWithOptions(opt *Options) (*Conn, error) {
 	if opt == nil {
 		return nil, ErrOptionsNotProvided
 	}
 	wac := &Conn{
-		handler:    make([]Handler, 0),
-		msgCount:   0,
-		msgTimeout: opt.Timeout,
-		Store:      newStore(),
+		handler:         make([]Handler, 0),
+		msgCount:        0,
+		msgTimeout:      opt.Timeout,
+		Store:           newStore(),
 		longClientName:  "github.com/Rhymen/go-whatsapp",
 		shortClientName: "go-whatsapp",
 		clientVersion:   "0.1.0",
@@ -299,4 +303,20 @@ func (wac *Conn) IsLoggedIn() bool {
 // Deprecated: function name is not go idiomatic, use IsLoggedIn instead.
 func (wac *Conn) GetLoggedIn() bool {
 	return wac.loggedIn
+}
+
+func (wac *Conn) autoUpdateMinorVersion() bool {
+	if !AutoUpdate {
+		return false
+	}
+	log.Println("received update command from the WhatsApp API")
+	if wac.autoUpdateTries > AutoUpdateMaxRetries {
+		log.Printf("auto update failed after %d tries", AutoUpdateMaxRetries)
+		return false
+	}
+	waVersionLock.Lock()
+	waVersion[1] += AutoUpdateIncrement
+	waVersionLock.Unlock()
+	wac.autoUpdateTries++
+	return true
 }

--- a/errors.go
+++ b/errors.go
@@ -22,6 +22,7 @@ var (
 	ErrInvalidWebsocket          = errors.New("invalid websocket")
 	ErrMessageTypeNotImplemented = errors.New("message type not implemented")
 	ErrOptionsNotProvided        = errors.New("new conn options not provided")
+	ErrUpdateRequired            = errors.New("waVersion not accepted (must update)")
 )
 
 type ErrConnectionFailed struct {

--- a/session.go
+++ b/session.go
@@ -588,7 +588,7 @@ func isUpdateResponse(rawstr string) bool {
 	if len(v) < 2 {
 		return false
 	}
-	if v[0] == nil {
+	if v[0] == nil || v[1] == nil {
 		return false
 	}
 	if vs, _ := v[0].(string); vs != "Cmd" {


### PR DESCRIPTION
An attempt to avoid errors like #631 
It's disabled by default to keep the original behaviour of this library:
```go
whatsapp.AutoUpdate = true
// this will bump the minor version by 10 if the command "update" is received on login
whatsapp.AutoUpdateIncrement = 10
whatsapp.AutoUpdateMaxRetries = 100
whatsapp.AutoUpdateRetryDelay = time.Millisecond * 500
```

This PR also returns a proper error instead of the usual "JSON marshal failed" (check `WhatsApp. ErrUpdateRequired`), so you can also act manually if this error is received.