### PR TITLE
add warning for unsupported go-whatsapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Package rhymen/go-whatsapp implements the WhatsApp Web API to provide a clean in
 
 ## Warning
 
-This package is not being actively maintained currently and will soon be unusuable as WhatsApp updates to multi-device. Please look at [adiwajshing/Baileys](https://github.com/adiwajshing/Baileys/tree/multi-device) for a NodeJS WhatsApp Web API that is actively maintained and supports WhatsApp multi-device.
+This package is not being actively maintained currently and will soon be unusuable as WhatsApp updates to multi-device. Please look at [tulir/whatsmeow](https://github.com/tulir/whatsmeow) for a Go WhatsApp Web API that is actively maintained and supports WhatsApp multi-device.
 
 ## Installation
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # go-whatsapp
 Package rhymen/go-whatsapp implements the WhatsApp Web API to provide a clean interface for developers. Big thanks to all contributors of the [sigalor/whatsapp-web-reveng](https://github.com/sigalor/whatsapp-web-reveng) project. The official WhatsApp Business API was released in August 2018. You can check it out [here](https://www.whatsapp.com/business/api).
 
+## Warning
+
+This package is not being actively maintained currently and will soon be unusuable as WhatsApp updates to multi-device. Please look at [adiwajshing/Baileys](https://github.com/adiwajshing/Baileys/tree/multi-device) for a NodeJS WhatsApp Web API that is actively maintained and supports WhatsApp multi-device.
+
 ## Installation
 ```sh
 go get github.com/Rhymen/go-whatsapp


### PR DESCRIPTION
Added a warning as this package is not currently being maintained. This should stop users from attempting to use it while multi-device rolls out and experiencing errors, or developing their own application to use this library, only to have it become unusable in a few weeks.

Any edits to the message are welcome.